### PR TITLE
Support glob patterns in branches: keys (config.yml + mirror.yml)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -112,6 +112,8 @@ reviewers:
 
 Names are user-chosen. The above is an example, not a fixed set. `required_checks` is optional; if omitted, only the reviewer gate applies.
 
+**Branch-key glob patterns:** entries under `branches:` accept the same `*` / `?` glob grammar as `mirror.yml`'s `tags:` and `branches:` (see `lib/refPatterns.ts`). A literal key like `main` still matches that one branch; a pattern like `release/*` matches any branch under that prefix. Resolution rule: an exact key wins over any glob; if no exact key matches, the rule looks for a glob that does. If two glob keys both match the pushed branch (e.g. `release/*` and `*/v3.2` against `release/v3.2`), the lookup throws — add an exact key for the overlapping name to disambiguate. Attestations always record `target_branch` as the literal pushed branch, so verifiers transparently re-resolve through the same glob path.
+
 **`required_checks` semantics (Phase 2.A):**
 
 - Each check is `{ name, run }` — `run` is a shell command.
@@ -125,8 +127,9 @@ Names are user-chosen. The above is an example, not a fixed set. `required_check
 ```yaml
 github:
   repo: owner/repo
-  branches:
+  branches:       # array of glob patterns; literal names like `main` match exactly
     - main
+    - "release/*"
   tags:           # optional; absent/empty = no tag mirroring
     - "v*"        # array of glob patterns, or `true` for all tags
 ```

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -162,6 +162,20 @@ branches:
 
 The gate runs against the rule for the branch you're merging into (`stamp merge <branch> --into <target>` reads `branches.<target>.required`). A reviewer can exist in `reviewers:` without being required by any branch — it still runs on `stamp review` but doesn't gate merges.
 
+Branch keys also accept `*` / `?` glob patterns. Common shapes:
+
+```yaml
+branches:
+  main:
+    required: [security, standards, product]
+  "release/*":            # everything under refs/heads/release/
+    required: [security, product]
+  "team-?/*":             # one-character team code, then anything
+    required: [security]
+```
+
+Lookup is exact-key-first: a literal `release/v3.2:` entry overrides `release/*` for that one branch. Two glob keys that both match the same branch (e.g. `release/*` and `*/v3.2`) is a config error — add an exact-match key for the overlap.
+
 ## Calibration workflow
 
 Writing a persona in the abstract doesn't work. Calibrate against real diffs:

--- a/docs/quickstart-server.md
+++ b/docs/quickstart-server.md
@@ -119,8 +119,9 @@ If you want a public GitHub mirror that deploy pipelines can integrate with:
    ```yaml
    github:
      repo: your-user/your-repo
-     branches:
+     branches:        # literal names or `*` / `?` glob patterns
        - main
+       - "release/*"
    ```
 4. **Set up the GitHub-side ruleset** on the mirror's `main` so only your designated mirror identity can update the branch. Without this, anyone with repo write access can `git push origin main` and bypass the entire stamp gate. See [`github-ruleset-setup.md`](./github-ruleset-setup.md) for the full walkthrough — both UI and CLI paths, plus a [`github-ruleset-template.json`](./github-ruleset-template.json) you can `gh api`-import after editing in your bypass actor's numeric ID. (Note: GitHub is phasing out the legacy "Branch protection rules" UI in favor of "Rulesets"; many newer repos only see the Ruleset surface now.)
 

--- a/server/README.md
+++ b/server/README.md
@@ -119,13 +119,17 @@ github:
   repo: your-user/your-repo       # GitHub "owner/repo" of the mirror destination
   branches:
     - main
+    - "release/*"                  # glob patterns; literal names match exactly
   tags:                            # optional — mirror tags to GitHub too
     - "v*"                         # glob patterns (or `true` for all tags)
 ```
 
-Only branches and tags listed here are mirrored. Other refs are pushed to your
-stamp server but not to GitHub. The `tags:` field is optional — when absent or
-empty, no tags are mirrored (the pre-0.7.8 behavior).
+Only branches and tags whose names match an entry are mirrored — `branches:`
+takes the same `*` / `?` glob grammar as `tags:`, so a literal `main` matches
+just that branch and `release/*` catches every branch under that prefix.
+Other refs are pushed to your stamp server but not to GitHub. The `tags:`
+field is optional — when absent or empty, no tags are mirrored (the
+pre-0.7.8 behavior).
 
 Tag mirroring exists for repos that publish on tag push (npm `on: push: tags`,
 Cargo, PyPI, etc.). Without it, `git push origin v1.0.0` lands on the stamp

--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_PRODUCT_PROMPT,
   DEFAULT_SECURITY_PROMPT,
   DEFAULT_STANDARDS_PROMPT,
+  findBranchRule,
   loadConfig,
   parseConfigFromYaml,
   stringifyConfig,
@@ -91,7 +92,7 @@ export async function runBootstrap(opts: BootstrapOptions = {}): Promise<void> {
   }
 
   const currentConfig = loadConfig(configFile);
-  const targetRule = currentConfig.branches[targetBranch];
+  const targetRule = findBranchRule(currentConfig.branches, targetBranch);
   if (!targetRule) {
     throw new Error(
       `.stamp/config.yml has no rule for branch "${targetBranch}". Switch to your protected branch first.`,

--- a/src/commands/merge.ts
+++ b/src/commands/merge.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { allPassed, runChecks } from "../lib/checks.js";
-import { loadConfig } from "../lib/config.js";
+import { findBranchRule, loadConfig } from "../lib/config.js";
 import { latestReviews, openDb } from "../lib/db.js";
 import { resolveDiff, runGit, showAtRef } from "../lib/git.js";
 import { ensureUserKeypair } from "../lib/keys.js";
@@ -72,7 +72,7 @@ export function runMerge(opts: MergeOptions): void {
   const revspec = `${opts.into}..${opts.branch}`;
   const resolved = resolveDiff(revspec, repoRoot);
 
-  const rule = config.branches[opts.into];
+  const rule = findBranchRule(config.branches, opts.into);
   if (!rule) {
     throw new Error(
       `no branch rule for "${opts.into}" in .stamp/config.yml`,
@@ -166,7 +166,7 @@ export function runMerge(opts: MergeOptions): void {
     //    diff). That case still needs the documented two-phase workaround
     //    (or `stamp bootstrap` for the placeholder→real swap).
     const postMergeConfig = loadConfig(stampConfigFile(repoRoot));
-    const postMergeRule = postMergeConfig.branches[opts.into];
+    const postMergeRule = findBranchRule(postMergeConfig.branches, opts.into);
     if (!postMergeRule) {
       throw new Error(
         `.stamp/config.yml in the merged tree has no rule for branch "${opts.into}" — ` +

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { loadConfig, type StampConfig } from "../lib/config.js";
+import { findBranchRule, loadConfig, type StampConfig } from "../lib/config.js";
 import { latestVerdicts, openDb, type Verdict } from "../lib/db.js";
 import { resolveDiff } from "../lib/git.js";
 import {
@@ -38,7 +38,7 @@ export function runStatus(opts: StatusOptions): void {
   const resolved = resolveDiff(opts.diff, repoRoot);
 
   const target = opts.into ?? inferTarget(opts.diff);
-  const rule = config.branches[target];
+  const rule = findBranchRule(config.branches, target);
   if (!rule) {
     throw new Error(
       `no branch rule for "${target}" in .stamp/config.yml. ` +

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -3,7 +3,11 @@ import {
   parseCommitAttestation,
   type AttestationPayload,
 } from "../lib/attestation.js";
-import { parseConfigFromYaml, type StampConfig } from "../lib/config.js";
+import {
+  findBranchRule,
+  parseConfigFromYaml,
+  type StampConfig,
+} from "../lib/config.js";
 import { findTrustedKey } from "../lib/keys.js";
 import { findRepoRoot } from "../lib/paths.js";
 import {
@@ -121,8 +125,10 @@ export function runVerify(sha: string): void {
     );
   }
 
-  // 5. Check approvals satisfy config for target branch.
-  const rule = config.branches[payload.target_branch];
+  // 5. Check approvals satisfy config for target branch. The lookup is
+  //    glob-aware: a config key of "release/*" resolves for a literal
+  //    target_branch of "release/v3.2".
+  const rule = findBranchRule(config.branches, payload.target_branch);
   if (!rule) {
     fail(
       sha,

--- a/src/hooks/post-receive.ts
+++ b/src/hooks/post-receive.ts
@@ -21,11 +21,20 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { parse as parseYaml } from "yaml";
-import { matchesAnyTagPattern, resolveTagPatterns } from "../lib/refPatterns.js";
+import {
+  matchesAnyPattern,
+  matchesAnyTagPattern,
+  resolveTagPatterns,
+} from "../lib/refPatterns.js";
 
 interface MirrorConfig {
   github?: {
     repo: string; // "owner/repo"
+    /**
+     * Branches to mirror. Each entry is a glob pattern (literal names like
+     * `main` are valid no-metachar globs and still match exactly). Same
+     * `*` / `?` grammar as the `tags:` field; see refPatterns.ts.
+     */
     branches: string[];
     /**
      * Glob patterns of tags to mirror, normalized by resolveTagPatterns.
@@ -87,7 +96,7 @@ function main(): void {
       const branch = refname.slice("refs/heads/".length);
       const cfg = readMirrorConfig(newSha);
       if (!cfg?.github) continue;
-      if (!cfg.github.branches.includes(branch)) continue;
+      if (!matchesAnyPattern(branch, cfg.github.branches)) continue;
       mirrorRef(`branch ${branch}`, refname, newSha, cfg.github.repo);
       continue;
     }
@@ -182,9 +191,11 @@ function mirrorRef(
 
 // Canonical schema shape used in warning messages. Matches the YAML
 // example in DESIGN.md and server/README.md so the operator sees
-// consistent text at every touchpoint.
+// consistent text at every touchpoint. Branch and tag entries both accept
+// glob patterns (`*`, `?`); literal names like `main` are no-metachar
+// globs and still match exactly.
 const SCHEMA_HINT =
-  "expected schema: github: { repo: owner/repo, branches: [main], tags?: [\"v*\"] | true }";
+  "expected schema: github: { repo: owner/repo, branches: [main, \"release/*\"], tags?: [\"v*\"] | true }";
 
 function readMirrorConfig(sha: string): MirrorConfig | null {
   // Absence of the file is normal — repos without mirror configured just
@@ -253,7 +264,7 @@ function readMirrorConfig(sha: string): MirrorConfig | null {
   }
   if (!Array.isArray(gh.branches)) {
     warn(
-      `mirror: .stamp/mirror.yml missing or non-array 'github.branches' (expected list of branch names) — skipping mirror. ${SCHEMA_HINT}.`,
+      `mirror: .stamp/mirror.yml missing or non-array 'github.branches' (expected list of branch names or glob patterns) — skipping mirror. ${SCHEMA_HINT}.`,
     );
     return null;
   }

--- a/src/hooks/pre-receive.ts
+++ b/src/hooks/pre-receive.ts
@@ -28,6 +28,7 @@ import {
   type AttestationPayload,
 } from "../lib/attestation.js";
 import { fingerprintFromPem } from "../lib/keys.js";
+import { globToRegex, isGlobPattern } from "../lib/refPatterns.js";
 import {
   hashMcpServers,
   hashPromptBytes,
@@ -93,7 +94,7 @@ function verifyRef(oldSha: string, newSha: string, refname: string): void {
     );
   }
 
-  const rule = config.branches[branch];
+  const rule = resolveBranchRule(config.branches, branch);
   if (!rule) {
     // Not a protected branch — pass.
     return;
@@ -358,6 +359,33 @@ function run(args: string[]): string {
       `git ${args.join(" ")} failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
+}
+
+/**
+ * Hook-local mirror of lib/config.ts's findBranchRule. Kept here so the
+ * hook stays self-contained (it already maintains its own readConfigAt /
+ * BranchRule shape rather than importing loadConfig). Same resolution
+ * rule: exact key first, then glob fallback, error on multi-glob match.
+ */
+function resolveBranchRule(
+  branches: Record<string, BranchRule>,
+  branchName: string,
+): BranchRule | undefined {
+  const exact = branches[branchName];
+  if (exact !== undefined) return exact;
+  const matchingKeys: string[] = [];
+  for (const key of Object.keys(branches)) {
+    if (!isGlobPattern(key)) continue;
+    if (globToRegex(key).test(branchName)) matchingKeys.push(key);
+  }
+  if (matchingKeys.length === 0) return undefined;
+  if (matchingKeys.length > 1) {
+    throw new Error(
+      `branch "${branchName}" matches multiple glob patterns in .stamp/config.yml: ${matchingKeys.map((k) => `"${k}"`).join(", ")}. ` +
+        `Tighten the patterns or add an exact-match key for "${branchName}".`,
+    );
+  }
+  return branches[matchingKeys[0]!];
 }
 
 function readConfigAt(sha: string): StampConfigAtRef | null {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { parse, stringify } from "yaml";
+import { globToRegex, isGlobPattern } from "./refPatterns.js";
 
 export interface CheckDef {
   /** Short name used in config and attestation payloads — e.g. "build", "test" */
@@ -229,6 +230,45 @@ function parseStringMap(input: unknown, path: string): Record<string, string> {
 
 export function stringifyConfig(config: StampConfig): string {
   return stringify(config);
+}
+
+/**
+ * Resolve the branch rule for a literal branch name. Map keys may be
+ * literal branch names OR glob patterns (`*`, `?` — same grammar as
+ * mirror.yml's `tags:` field; see refPatterns.ts).
+ *
+ * Resolution rule, exact-first then glob:
+ *   1. If a key matches `branchName` literally, that rule wins. Exact
+ *      keys without metacharacters never participate in glob matching.
+ *   2. Otherwise, scan keys that contain `*` or `?` and test each as a
+ *      glob. If exactly one matches, return it. If multiple match, throw
+ *      with the conflicting keys named so the operator can disambiguate.
+ *   3. If nothing matches, return undefined.
+ *
+ * The undefined return mirrors the prior `branches[name]` behavior so
+ * callers that treat "no rule = unprotected" still work. Callers that
+ * require a rule should keep their existing throw with the same wording.
+ */
+export function findBranchRule(
+  branches: Record<string, BranchRule>,
+  branchName: string,
+): BranchRule | undefined {
+  const exact = branches[branchName];
+  if (exact !== undefined) return exact;
+
+  const matchingKeys: string[] = [];
+  for (const key of Object.keys(branches)) {
+    if (!isGlobPattern(key)) continue;
+    if (globToRegex(key).test(branchName)) matchingKeys.push(key);
+  }
+  if (matchingKeys.length === 0) return undefined;
+  if (matchingKeys.length > 1) {
+    throw new Error(
+      `branch "${branchName}" matches multiple glob patterns in .stamp/config.yml: ${matchingKeys.map((k) => `"${k}"`).join(", ")}. ` +
+        `Tighten the patterns or add an exact-match key for "${branchName}".`,
+    );
+  }
+  return branches[matchingKeys[0]!];
 }
 
 /**

--- a/src/lib/refPatterns.ts
+++ b/src/lib/refPatterns.ts
@@ -1,15 +1,16 @@
 /**
- * Glob matching for git ref names in `.stamp/mirror.yml`'s `tags:` field.
+ * Glob matching for git ref names — used by `.stamp/mirror.yml`'s `tags:`
+ * and `branches:` fields, and by `.stamp/config.yml`'s `branches:` map keys.
  *
- * Operators write patterns like `v*` or `release-*` and expect shell-style
- * glob semantics, not regex. We accept exactly two metacharacters:
+ * Operators write patterns like `v*`, `release/*`, or `team-?` and expect
+ * shell-style glob semantics, not regex. We accept exactly two metacharacters:
  *
  *   *   matches zero or more characters (including `/`)
  *   ?   matches exactly one character
  *
  * Everything else is escaped, so a literal pattern like `v1.0.0` matches
  * the tag named `v1.0.0` and not `v1x0x0`. We deliberately do not support
- * `**`, character classes, or `{a,b}` alternation — tag names rarely
+ * `**`, character classes, or `{a,b}` alternation — ref names rarely
  * benefit from them and the more elaborate the syntax, the more surprising
  * the failure modes are when an operator writes the wrong thing.
  *
@@ -58,12 +59,28 @@ export function resolveTagPatterns(raw: unknown): string[] | null {
 }
 
 /**
- * Test whether a tag name matches any of the configured patterns.
- * Empty pattern list returns false (= no tag mirroring).
+ * Test whether a ref name matches any of the configured glob patterns.
+ * Empty pattern list returns false (= no match).
+ *
+ * Used for both branch and tag matching — a literal entry like `main`
+ * still works (no metachars → exact-string regex), so callers don't need
+ * to special-case literal vs. pattern entries.
  */
-export function matchesAnyTagPattern(tagName: string, patterns: string[]): boolean {
+export function matchesAnyPattern(name: string, patterns: string[]): boolean {
   for (const pattern of patterns) {
-    if (globToRegex(pattern).test(tagName)) return true;
+    if (globToRegex(pattern).test(name)) return true;
   }
   return false;
+}
+
+/** Back-compat alias — predates the branch use case. New callers should
+ *  use `matchesAnyPattern`, which is the same function under a name-agnostic
+ *  spelling. */
+export const matchesAnyTagPattern = matchesAnyPattern;
+
+/** True if a config key/entry is a glob pattern (contains `*` or `?`)
+ *  rather than a literal ref name. Used by config.yml branch lookup to
+ *  distinguish exact-match keys from pattern keys. */
+export function isGlobPattern(s: string): boolean {
+  return s.includes("*") || s.includes("?");
 }

--- a/tests/validators.test.ts
+++ b/tests/validators.test.ts
@@ -53,9 +53,12 @@ import {
 } from "../src/commands/serverRepo.ts";
 import {
   globToRegex,
+  isGlobPattern,
+  matchesAnyPattern,
   matchesAnyTagPattern,
   resolveTagPatterns,
 } from "../src/lib/refPatterns.ts";
+import { findBranchRule, type BranchRule } from "../src/lib/config.ts";
 import { parseServerConfig as parseServerYaml } from "../src/lib/serverConfig.ts";
 
 // ---------- parseGithubOriginUrl ----------
@@ -537,6 +540,114 @@ describe("matchesAnyTagPattern", () => {
     assert.equal(matchesAnyTagPattern("v1.0.0", ["*"]), true);
     assert.equal(matchesAnyTagPattern("hotfix-2026", ["*"]), true);
     assert.equal(matchesAnyTagPattern("", ["*"]), true);
+  });
+});
+
+// ---------- glob matching for branch refs (issue #9) ----------
+
+describe("matchesAnyPattern (branch / generic ref names)", () => {
+  it("matches a literal branch name without metachars", () => {
+    assert.equal(matchesAnyPattern("main", ["main"]), true);
+    assert.equal(matchesAnyPattern("develop", ["main"]), false);
+  });
+
+  it("matches a glob with slashes — release/v3.2 against release/*", () => {
+    // The * metachar must cross /, otherwise common branch families like
+    // `release/*` or `team-foo/feature` wouldn't be expressible.
+    assert.equal(matchesAnyPattern("release/v3.2", ["release/*"]), true);
+    assert.equal(matchesAnyPattern("release/v3.2/hotfix", ["release/*"]), true);
+  });
+
+  it("returns true if any of multiple patterns match", () => {
+    assert.equal(matchesAnyPattern("staging", ["main", "staging", "release/*"]), true);
+    assert.equal(matchesAnyPattern("release/v1", ["main", "release/*"]), true);
+  });
+
+  it("empty pattern list never matches", () => {
+    assert.equal(matchesAnyPattern("main", []), false);
+  });
+
+  it("matchesAnyTagPattern is the same function under the back-compat name", () => {
+    // Pin the alias so a future rename doesn't silently change behavior.
+    assert.equal(matchesAnyTagPattern, matchesAnyPattern);
+  });
+});
+
+describe("isGlobPattern", () => {
+  it("returns true for strings with * or ?", () => {
+    assert.equal(isGlobPattern("release/*"), true);
+    assert.equal(isGlobPattern("v?.0"), true);
+    assert.equal(isGlobPattern("*"), true);
+  });
+
+  it("returns false for plain literal names", () => {
+    assert.equal(isGlobPattern("main"), false);
+    assert.equal(isGlobPattern("release/v1"), false);
+    assert.equal(isGlobPattern(""), false);
+  });
+});
+
+describe("findBranchRule (config.yml branches: glob support, issue #9)", () => {
+  const ruleMain: BranchRule = { required: ["security"] };
+  const ruleRelease: BranchRule = { required: ["security", "standards"] };
+  const ruleTeam: BranchRule = { required: ["product"] };
+
+  it("returns undefined when no key matches (unprotected branch)", () => {
+    const branches = { main: ruleMain };
+    assert.equal(findBranchRule(branches, "feature/x"), undefined);
+  });
+
+  it("returns the rule on exact key match", () => {
+    const branches = { main: ruleMain };
+    assert.equal(findBranchRule(branches, "main"), ruleMain);
+  });
+
+  it("falls back to glob match when no exact key", () => {
+    const branches = { "release/*": ruleRelease };
+    assert.equal(findBranchRule(branches, "release/v3.2"), ruleRelease);
+  });
+
+  it("exact key wins over glob (more specific intent)", () => {
+    // An operator who wrote both `release/v3.2: ...` and `release/*: ...`
+    // expects the exact key to govern that one branch and the glob to
+    // catch the rest. Pin the precedence so a future refactor can't
+    // accidentally flip it.
+    const branches = {
+      "release/*": ruleRelease,
+      "release/v3.2": ruleMain,
+    };
+    assert.equal(findBranchRule(branches, "release/v3.2"), ruleMain);
+    assert.equal(findBranchRule(branches, "release/v4.0"), ruleRelease);
+  });
+
+  it("throws with both keys named when multiple globs match the same branch", () => {
+    // Ambiguous configs are surfaced as errors rather than silently
+    // resolved by insertion order — the operator almost certainly meant
+    // to write a more specific exact key for the overlap case.
+    const branches = {
+      "release/*": ruleRelease,
+      "*/v3.2": ruleTeam,
+    };
+    assert.throws(
+      () => findBranchRule(branches, "release/v3.2"),
+      (err: Error) => {
+        assert.match(err.message, /matches multiple glob patterns/);
+        assert.match(err.message, /"release\/\*"/);
+        assert.match(err.message, /"\*\/v3\.2"/);
+        return true;
+      },
+    );
+  });
+
+  it("literal keys never participate in glob matching", () => {
+    // Without this, a literal key like `main` would pass globToRegex too
+    // (no metachars → exact-string regex), which is fine for `main` but
+    // would change semantics for keys that happen to contain `.` or
+    // `+` — those would gain regex-meta meaning if treated as patterns.
+    // Guard with isGlobPattern at the call site so literals stay literal.
+    const branches = { "main.staging": ruleMain };
+    assert.equal(findBranchRule(branches, "mainXstaging"), undefined);
+    assert.equal(findBranchRule(branches, "main.staging"), ruleMain);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #9. Branch-rule lookup in `.stamp/config.yml` and the branch list in `.stamp/mirror.yml` now accept the same `*` / `?` glob grammar that `mirror.yml`'s `tags:` field has used since 0.7.8. Literal names continue to work unchanged (no metachars → exact-string match).

**`config.yml` resolution rule:** exact key wins over glob; if no exact key matches, the lookup scans glob-shaped keys; multiple glob keys matching the same branch is a config error with both keys named so the operator can disambiguate.

**`mirror.yml` `branches:`** now evaluates each entry as a glob; first match wins (same posture as `tags:`).

## Implementation notes

- Added `findBranchRule(branches, name)` to `src/lib/config.ts`; threaded through `merge`, `status`, `verify`, `bootstrap`. Verifier transparently re-resolves through the same path because `target_branch` in the attestation is always the literal pushed branch.
- `src/hooks/pre-receive.ts` keeps a self-contained `resolveBranchRule` mirror (the hook already maintains its own `BranchRule` shape rather than importing `loadConfig`); same resolution rule + error wording so an operator sees the same prose whether the conflict surfaces locally or via push rejection.
- Generalized `matchesAnyTagPattern` → `matchesAnyPattern` in `src/lib/refPatterns.ts`; `matchesAnyTagPattern` is preserved as a back-compat alias (and pinned by a test).
- Updated `DESIGN.md`, `docs/personas.md`, `docs/quickstart-server.md`, `server/README.md` with short notes on the precedence rule.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — all 77 tests pass (13 new cases added for `matchesAnyPattern`, `isGlobPattern`, and the three resolution paths of `findBranchRule`)
- [x] `npm run build` clean
- [x] `stamp review --diff pardini..fix/issue-9` — security / standards / product all approved
- [ ] Human spot-check of the glob precedence semantics against any in-flight repos with branch families

🤖 Generated with [Claude Code](https://claude.com/claude-code)