### PR TITLE
test: PR-mediated bypass attempt (deploy-key verification)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stamp-cli
 
-Local, headless pull-request system for agent-to-agent code review workflows.
+Local, headless pull-request system for agent-to-agent code-review workflows.
 
 An author-agent opens a diff, reviewer-agents consume it and return structured
 feedback, the author iterates until merge rules are satisfied, and the merge


### PR DESCRIPTION
Verifying that GitHub's `stamp-mirror-only` Ruleset rejects PR merges by users not in the deploy-key bypass list. Expected: merge attempt is rejected. Will be closed and branch deleted regardless of outcome.